### PR TITLE
file: remove support for Content-Disposition filename

### DIFF
--- a/warehouse/file.py
+++ b/warehouse/file.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import os
-import cgi
+import email
 import shutil
 
 from warehouse.errors import WarehouseClientException
@@ -76,11 +76,7 @@ class WHFile():
             try:
                 filename = req.headers['x-content-filename']
             except KeyError:
-                try:
-                    header = cgi.parse_header(req.headers['content-disposition'])
-                    filename = header[1]['filename']
-                except (KeyError, IndexError):
-                    pass
+                pass
     
             if path is not None:
                 basename = os.path.basename(path)


### PR DESCRIPTION
warehouse has included the X-Content-Filename header since 2018, so the parsing of Content-Disposition is effectively dead code.